### PR TITLE
Fix cmake installation conflict in macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: matrix.os == 'macos-latest'
       run: |
+        brew uninstall cmake
         brew install cpr nlohmann-json cmake
     
     - name: Install Chocolatey and dependencies (Windows)


### PR DESCRIPTION
This PR fixes the cmake installation issue in the macOS CI job by uninstalling the conflicting version before installing the required one.