### PR TITLE
Fix Windows build issues with STL types in DLL exports

### DIFF
--- a/include/core/agent.h
+++ b/include/core/agent.h
@@ -1,8 +1,17 @@
 #pragma once
+#include "utils/config.h"  // For LLAMAWARE_API
+
+// Forward declarations for STL types
 #include <string>
 #include <memory>
 #include <vector>
-#include "utils/config.h"  // For LLAMAWARE_API
+
+// Forward declare STL types that will be used in the interface
+namespace std {
+    template class LLAMAWARE_API std::allocator<char>;
+    template class LLAMAWARE_API std::basic_string<char, std::char_traits<char>, std::allocator<char>>;
+    template <class T, class D> class LLAMAWARE_API unique_ptr;
+}
 
 namespace Data { class MemoryManager; }
 namespace Services { class AIService; }

--- a/include/utils/config.h
+++ b/include/utils/config.h
@@ -1,16 +1,29 @@
 #pragma once
-#include <string>
 
 // Define DLL export/import macros for Windows
 #if defined(_WIN32) || defined(_WIN64)
     #ifdef LLAMAWARE_LIBRARY
         #define LLAMAWARE_API __declspec(dllexport)
+        // Disable warning about STL types in the interface
+        #pragma warning(disable: 4251)
     #else
         #define LLAMAWARE_API __declspec(dllimport)
+    #endif
+    
+    // Enable secure CRT functions
+    #ifndef _CRT_SECURE_NO_WARNINGS
+        #define _CRT_SECURE_NO_WARNINGS
+    #endif
+    
+    // Disable min/max macros from windows.h
+    #ifndef NOMINMAX
+        #define NOMINMAX
     #endif
 #else
     #define LLAMAWARE_API __attribute__((visibility("default")))
 #endif
+
+#include <string>
 
 namespace Utils {
     namespace Config {


### PR DESCRIPTION
## Description
This PR fixes Windows build issues related to STL types in DLL exports. The main changes include:

- Added proper STL type handling in DLL exports
- Updated  with Windows-specific settings
- Disabled warning 4251 for STL types in DLL interface
- Added  and  definitions

## Testing
These changes should resolve the Windows build errors while maintaining compatibility with other platforms.

## Related Issues
Closes #32 (partially)