### PR TITLE
Add missing package structure folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 build/
 bin/
 lib/
+dist/
 cmake-build-*/
 *.sln
 *.vcxproj*

--- a/package/README.md
+++ b/package/README.md
@@ -13,6 +13,8 @@ package/
 └── dist/             # Generated files
 ```
 
+Note: The `dist/` folder contains generated files from the build process and is ignored in .gitignore.
+
 ## Distribution Methods
 - Binary: Pre-compiled binaries with installers
 - Container: Docker images and orchestration

--- a/package/docs/DISTRIBUTION.md
+++ b/package/docs/DISTRIBUTION.md
@@ -1,0 +1,18 @@
+# Distribution Documentation
+
+## Overview
+
+This directory contains documentation related to packaging, distribution, and deployment of Llamaware.
+
+## Contents
+
+- Binary distributions
+- Container images
+- Package manager configurations
+- Build and release scripts
+
+## Guides
+
+- [Binary Installation](binary/install.sh)
+- [Docker Deployment](docker/)
+- [Homebrew Package](managers/homebrew/llamaware.rb)


### PR DESCRIPTION
This PR addresses issue #36 by adding the missing docs/ and dist/ folders to the package/ directory, along with DISTRIBUTION.md documentation, .gitignore updates, and a note in the README.

Changes:
- Created package/docs/ and package/dist/ folders
- Added DISTRIBUTION.md in package/docs/
- Updated .gitignore to ignore dist/
- Added explanatory note in package/README.md

Closes #36