### PR TITLE
Fix Homebrew SHA256 for v0.1

### DIFF
--- a/package/docs/CHANGELOG.md
+++ b/package/docs/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-09-25
+
+### Added
+- Initial release of llamaware-agent
+- Command execution and file operations
+- AI integration with various providers
+- Package structure with Homebrew formula
+
+### Fixed
+- Corrected SHA256 in Homebrew formula
+
+### Changed
+- Updated package documentation

--- a/package/managers/homebrew/llamaware.rb
+++ b/package/managers/homebrew/llamaware.rb
@@ -2,7 +2,7 @@ class Llamaware < Formula
   desc "Professional AI agent with command execution and file operations"
   homepage "https://github.com/harpertoken/llamaware"
   url "https://github.com/harpertoken/llamaware/archive/v0.1.tar.gz"
-  sha256 "YOUR_SHA256_HERE"
+  sha256 "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed"
   license "MIT"
 
   depends_on "cmake" => :build


### PR DESCRIPTION
## Summary
- Corrects the SHA256 hash in the Homebrew formula for the v0.1 release tarball
- Ensures the formula can successfully install the package