### PR TITLE
Fix CodeQL configuration warning for JavaScript language

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp' ]
+        language: [ 'cpp', 'javascript' ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary
- Added 'javascript' to the CodeQL workflow languages matrix to resolve the configuration warning.
- This ensures CodeQL can properly scan for JavaScript code, even if none is present, eliminating the warning about missing configuration.

Fixes #39