### PR TITLE
fix(ci): Correct workflow to use vars for dynamic configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,17 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: ${{ fromJSON(env.PUSH_BRANCHES) }}
+    branches: ${{ fromJSON(vars.PUSH_BRANCHES) }}
   pull_request:
-    branches: ${{ fromJSON(env.PR_BRANCHES) }}
+    branches: ${{ fromJSON(vars.PR_BRANCHES) }}
   release:
-    types: ${{ fromJSON(env.RELEASE_TYPES) }}
+    types: ${{ fromJSON(vars.RELEASE_TYPES) }}
 
 env:
   # Read values from repo-level variables
-  PUSH_BRANCHES: ${{ env.PUSH_BRANCHES }}
-  PR_BRANCHES: ${{ env.PR_BRANCHES }}
-  RELEASE_TYPES: ${{ env.RELEASE_TYPES }}
+  PUSH_BRANCHES: ${{ vars.PUSH_BRANCHES }}
+  PR_BRANCHES: ${{ vars.PR_BRANCHES }}
+  RELEASE_TYPES: ${{ vars.RELEASE_TYPES }}
 
 permissions:
   actions: read


### PR DESCRIPTION
Fixes invalid workflow file by using 'vars' instead of 'env' for repository variables in trigger conditions.

## Changes
- Changed  triggers to use , , 
- Updated  section to reference  instead of 

This resolves the 'Unrecognized named-value: env' errors.