### PR TITLE
fix(ci): Hardcode workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: ${{ fromJSON(vars.PUSH_BRANCHES) }}
+    branches: ["main","develop"]
   pull_request:
-    branches: ${{ fromJSON(vars.PR_BRANCHES) }}
+    branches: ["*"]
   release:
-    types: ${{ fromJSON(vars.RELEASE_TYPES) }}
+    types: ["published"]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Fixes invalid workflow by using hardcoded values in on: section instead of vars. Repository variables remain in env: for job use.

Closes #55