### PR TITLE
fix: Remove unused exception variable

### DIFF
--- a/src/services/github_service.cpp
+++ b/src/services/github_service.cpp
@@ -289,7 +289,7 @@ int GitHubService::create_milestone(const std::string& owner,
     try {
         nlohmann::json json = nlohmann::json::parse(response.content);
         return json["number"];
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
         return -1;
     }
 }


### PR DESCRIPTION
Fixes MSVC compilation error by removing unused 'e' variable in catch block. Allows warnings-as-errors to pass.