### PR TITLE
Add clang-tidy linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y clang-tidy clang-tools cmake build-essential libcurl4-openssl-dev nlohmann-json3-dev
+
+      - name: Configure CMake
+        run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Run clang-tidy
+        run: |
+          cd build
+          run-clang-tidy -p . ../src ../include


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to run clang-tidy static analysis on the C++ codebase. It generates compile commands and checks for code quality issues on pushes and pull requests to main.