### PR TITLE
Make libpqxx optional to fix CMake build on systems without PostgreSQL client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,10 +396,8 @@ set(SERVICE_SOURCES
     src/services/auth_service.cpp
     src/services/error_service.cpp
     src/services/sandbox_service.cpp
+    src/services/database_service.cpp
 )
-if(HAVE_PQXX)
-    list(APPEND SERVICE_SOURCES src/services/database_service.cpp)
-endif()
 
 set(UTILS_SOURCES
     src/utils/ui.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,11 +202,15 @@ if(NOT nlohmann_json_FOUND)
     FetchContent_MakeAvailable(nlohmann_json)
 endif()
 
-# Find libpqxx
-find_library(PQXX_LIBRARY pqxx REQUIRED)
-find_path(PQXX_INCLUDE_DIR pqxx/pqxx REQUIRED)
-if(NOT PQXX_LIBRARY OR NOT PQXX_INCLUDE_DIR)
-    message(FATAL_ERROR "libpqxx not found. Please install libpqxx.")
+# Find libpqxx (optional)
+find_library(PQXX_LIBRARY pqxx)
+find_path(PQXX_INCLUDE_DIR pqxx/pqxx)
+if(PQXX_LIBRARY AND PQXX_INCLUDE_DIR)
+    set(HAVE_PQXX TRUE)
+    message(STATUS "Found libpqxx: ${PQXX_LIBRARY}")
+else()
+    set(HAVE_PQXX FALSE)
+    message(WARNING "libpqxx not found. Database support will be disabled. Install libpqxx-dev to enable PostgreSQL support.")
 endif()
 
 # Find CPR - try to find the package first
@@ -392,8 +396,10 @@ set(SERVICE_SOURCES
     src/services/auth_service.cpp
     src/services/error_service.cpp
     src/services/sandbox_service.cpp
-    src/services/database_service.cpp
 )
+if(HAVE_PQXX)
+    list(APPEND SERVICE_SOURCES src/services/database_service.cpp)
+endif()
 
 set(UTILS_SOURCES
     src/utils/ui.cpp
@@ -421,11 +427,11 @@ target_include_directories(llamaware_lib PUBLIC
     ${CURL_INCLUDE_DIRS}
     ${OPENSSL_INCLUDE_DIR}
     ${ZLIB_INCLUDE_DIRS}
-    ${PQXX_INCLUDE_DIR}
+    $<$<BOOL:${HAVE_PQXX}>:${PQXX_INCLUDE_DIR}>
 )
 
 # Set compile definitions for symbol visibility
-target_compile_definitions(llamaware_lib PRIVATE LLAMAWARE_LIBRARY)
+target_compile_definitions(llamaware_lib PRIVATE LLAMAWARE_LIBRARY $<$<BOOL:${HAVE_PQXX}>:HAVE_PQXX>)
 set_target_properties(llamaware_lib PROPERTIES
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON
@@ -459,7 +465,7 @@ target_link_libraries(llamaware_lib PRIVATE
     ${ZLIB_TARGET}
     ${CMAKE_DL_LIBS}
     Threads::Threads
-    ${PQXX_LIBRARY}
+    $<$<BOOL:${HAVE_PQXX}>:${PQXX_LIBRARY}>
 )
 
 # Set additional linker flags for macOS

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 * cpr 1.10.0+
 * nlohmann-json 3.10.0+
 * OpenSSL 1.1.1+
+* libpqxx 7.0+ (optional, for PostgreSQL database support)
 
 ## Project Structure
 
@@ -55,6 +56,8 @@ cd llamaware
 ```bash
 sudo apt update
 sudo apt install -y build-essential cmake git libcurl4-openssl-dev
+# Optional: for PostgreSQL database support
+sudo apt install -y libpqxx-dev
 make install-deps-ubuntu
 ```
 
@@ -62,12 +65,16 @@ make install-deps-ubuntu
 
 ```bash
 brew install cmake
+# Optional: for PostgreSQL database support
+brew install libpqxx
 ```
 
 **Windows**
 
 ```powershell
 # Install Chocolatey, CMake, and vcpkg (see CI workflow)
+# Optional: for PostgreSQL database support
+vcpkg install libpqxx
 ```
 
 ### Build
@@ -135,6 +142,28 @@ docker volume ls
 * **DeepSeek** – Advanced reasoning models
 * **OpenAI** – GPT models
 * **Offline** – Ollama (llama3.2:3b, latest)
+
+## Database Support
+
+Llamaware includes optional PostgreSQL database integration for persistent memory storage.
+
+**Features**
+* Conversation history persistence
+* Fact and preference storage
+* Session state management
+* Automatic schema initialization
+
+**Configuration**
+Set environment variables for database connection:
+```bash
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=llamaware
+DB_USER=llamaware
+DB_PASSWORD=your_password
+```
+
+**Note**: Database support is automatically enabled if libpqxx is available at build time. Without it, memory is stored in local files.
 
 ## GitHub Bot
 

--- a/include/services/database_service.h
+++ b/include/services/database_service.h
@@ -4,7 +4,26 @@
 #include <string>
 #include <memory>
 #include <vector>
+#ifdef HAVE_PQXX
 #include <pqxx/pqxx>
+#endif
+
+#ifndef HAVE_PQXX
+namespace pqxx {
+class result {
+public:
+    result() {}
+    size_t size() const { return 0; }
+    // Minimal interface for compatibility
+};
+class connection {
+public:
+    connection(const std::string&) {}
+    bool is_open() const { return false; }
+    std::string dbname() const { return ""; }
+};
+} // namespace pqxx
+#endif
 
 namespace llamaware {
 
@@ -24,7 +43,9 @@ public:
     std::unique_ptr<pqxx::result> executeSelect(const std::string& query, const std::vector<std::string>& params = {});
 
 private:
+#ifdef HAVE_PQXX
     std::unique_ptr<pqxx::connection> connection_;
+#endif
 };
 
 } // namespace llamaware

--- a/src/services/database_service.cpp
+++ b/src/services/database_service.cpp
@@ -4,14 +4,19 @@
 
 namespace llamaware {
 
-DatabaseService::DatabaseService() : connection_(nullptr) {}
+DatabaseService::DatabaseService()
+#ifdef HAVE_PQXX
+    : connection_(nullptr)
+#endif
+{}
 
 DatabaseService::~DatabaseService() {
     disconnect();
 }
 
 bool DatabaseService::connect(const std::string& host, int port, const std::string& dbname,
-                              const std::string& user, const std::string& password) {
+                               const std::string& user, const std::string& password) {
+#ifdef HAVE_PQXX
     try {
         std::string connection_string = "host=" + host +
                                        " port=" + std::to_string(port) +
@@ -29,14 +34,23 @@ bool DatabaseService::connect(const std::string& host, int port, const std::stri
         std::cerr << "Database connection error: " << e.what() << std::endl;
         return false;
     }
+#else
+    return false;
+#endif
 }
 
 void DatabaseService::disconnect() {
+#ifdef HAVE_PQXX
     connection_.reset();
+#endif
 }
 
 bool DatabaseService::isConnected() const {
+#ifdef HAVE_PQXX
     return connection_ && connection_->is_open();
+#else
+    return false;
+#endif
 }
 
 bool DatabaseService::executeQuery(const std::string& query, const std::vector<std::string>& params) {

--- a/src/services/database_service.cpp
+++ b/src/services/database_service.cpp
@@ -54,6 +54,7 @@ bool DatabaseService::isConnected() const {
 }
 
 bool DatabaseService::executeQuery(const std::string& query, const std::vector<std::string>& params) {
+#ifdef HAVE_PQXX
     if (!isConnected()) {
         std::cerr << "Not connected to database" << std::endl;
         return false;
@@ -84,9 +85,16 @@ bool DatabaseService::executeQuery(const std::string& query, const std::vector<s
         std::cerr << "Query execution error: " << e.what() << std::endl;
         return false;
     }
+#else
+    (void)query;
+    (void)params;
+    std::cerr << "Database support is disabled as libpqxx is not available." << std::endl;
+    return false;
+#endif
 }
 
 std::unique_ptr<pqxx::result> DatabaseService::executeSelect(const std::string& query, const std::vector<std::string>& params) {
+#ifdef HAVE_PQXX
     if (!isConnected()) {
         std::cerr << "Not connected to database" << std::endl;
         return nullptr;
@@ -119,6 +127,12 @@ std::unique_ptr<pqxx::result> DatabaseService::executeSelect(const std::string& 
         std::cerr << "Select query error: " << e.what() << std::endl;
         return nullptr;
     }
+#else
+    (void)query;
+    (void)params;
+    std::cerr << "Database support is disabled as libpqxx is not available." << std::endl;
+    return nullptr;
+#endif
 }
 
 } // namespace llamaware


### PR DESCRIPTION
This PR addresses issue #79 by making libpqxx an optional dependency.

**Changes:**
- Modified CMakeLists.txt to conditionally find and link libpqxx
- Added HAVE_PQXX compile definition when libpqxx is available
- Conditionally include database_service.cpp in the build
- Provided stub implementations in database_service.h/.cpp for systems without pqxx
- Database functionality is gracefully disabled when libpqxx is not installed

**Benefits:**
- Project builds successfully on systems without PostgreSQL client libraries
- Database support is automatically enabled when libpqxx is detected
- No breaking changes for systems with pqxx installed

**Testing:**
- Verified build succeeds without libpqxx
- Confirmed database features work when libpqxx is present (via CI)